### PR TITLE
Some improvements to account auth

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -109,7 +109,7 @@
 						<div class="input-group" id="authentication-captcha">
 						</div>
 						<br>
-						<p>Creating an account is not avaliable at this time.</p>
+						<p>Creating an account is not avaliable at this time. Please use the <a href="//computernewb.com/collab-vm">new webapp</a> to create and manage accounts.</p>
 					</div>
 					<div class="modal-footer">
 						<button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
@@ -206,7 +206,7 @@
 						<button class="btn btn-default" type="button" id="turn-btn">Take Turn</button>
 						<button style="display:none;" class="btn btn-default" type="button" id="end-turn-btn">End Turn</button>
 						<button class="btn btn-default" type="button" id="osk-btn">Keyboard</button>
-						<button class="btn btn-default" type="button" data-toggle="modal" data-target="#username-modal" id="username-btn" disabled>Change Username</button>
+						<button class="btn btn-default" type="button" id="username-btn" disabled>Change Username</button>
 						<button style="display: none;" class="btn btn-default" type="button" id="vote-btn">Vote for Reset</button>
 						<button style="display: none;" class="btn btn-default" type="button" id="pip-btn">Picture-in-Picture</button>
 						<button class="btn btn-default" type="button" id="upload-options-btn">Upload File</button>

--- a/src/js/collab-vm/collab-vm.js
+++ b/src/js/collab-vm/collab-vm.js
@@ -686,7 +686,6 @@ function InitalizeGuacamoleClient() {
 	});
 
 	$("#username-btn").prop("disabled", false);
-	$("#username-btn").show();
 	$("#username-btn").click(function() {
 		if (authUrl === "") {
 			$("#username-modal").modal("show");
@@ -730,7 +729,6 @@ function InitalizeGuacamoleClient() {
 			session = "";
 			$("#authentication-captcha").html("");
 			$("#username-btn").html("Change Username");
-			$("#username-btn").show();
 			$("#username-btn").prop("disabled", true);
 			$("#chat-user").off("click");
 			activateOSK(false);

--- a/src/js/collab-vm/collab-vm.js
+++ b/src/js/collab-vm/collab-vm.js
@@ -728,6 +728,7 @@ function InitalizeGuacamoleClient() {
 			authUrl = "";
 			loggedIn = false;
 			session = "";
+			$("#authentication-captcha").html("");
 			$("#username-btn").html("Change Username");
 			$("#username-btn").show();
 			$("#username-btn").prop("disabled", true);


### PR DESCRIPTION
I've made a few minor changes to how account authentication is implemented
- Instead of immediately showing the login modal, the change username button is repurposed to function as a login/logout button
- logout functionality implemented
- we now handle login error codes other than 400
- the captcha is properly reset after login, and unrendered on socket close